### PR TITLE
Update include directive to match case-sensitive filename

### DIFF
--- a/Lzhl_tcp.cpp
+++ b/Lzhl_tcp.cpp
@@ -17,7 +17,7 @@
 #include <map>
 using namespace std;
 #include "lzhl.h"
-#include "lzhl_tcp.h"
+#include "Lzhl_tcp.h"
 
 typedef unsigned char BYTE;
 


### PR DESCRIPTION
The filename in the include directive was adjusted to match the correct case-sensitive spelling of "Lzhl_tcp.h".

This change ensures compatibility with case-sensitive file systems and prevents potential build errors.