### PR TITLE
Fix INT32 & UINT32 type on non-windows platforms

### DIFF
--- a/_lzhl.h
+++ b/_lzhl.h
@@ -33,7 +33,7 @@
 #endif
 
 #ifndef INT32
-#define INT32 signed long
+#define INT32 signed int
 #endif
 
 #ifndef UINT16
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef UINT32
-#define UINT32 unsigned long
+#define UINT32 unsigned int
 #endif
 
 #ifndef BOOL


### PR DESCRIPTION
`unsigned long` is not 4-byte wide on non-windows platforms