### PR TITLE
Fix memory read past array bounds

### DIFF
--- a/Lz.cpp
+++ b/Lz.cpp
@@ -230,7 +230,7 @@ size_t LZHLCompressor::compress( BYTE* dst, const BYTE* src, size_t sz )
                 if( matchLen > lazyMatchLen )
                     {
                     coder.putMatch( src, nRaw, matchLen - LZMIN, _distance( wrapBufPos - hashPos ) );
-                    hash = _updateTable( hash, src + nRaw, bufPos + 1, min( matchLen - 1, srcEnd - (src + nRaw + 1) ) );
+                    hash = _updateTable( hash, src + nRaw, bufPos + 1, min( matchLen - 1, srcEnd - (src + nRaw + 1) - LZMATCH ) );
                     _toBuf( src + nRaw, matchLen );
                     src += nRaw + matchLen;
                     break;//for( nRaw )
@@ -244,7 +244,7 @@ size_t LZHLCompressor::compress( BYTE* dst, const BYTE* src, size_t sz )
                     UPDATE_HASH_EX( hash, src + nRaw );
 
                     coder.putMatch( src, nRaw, lazyMatchLen - LZMIN, _distance( bufPos - lazyMatchHashPos ) );
-                    hash = _updateTable( hash, src + nRaw + 1, bufPos + 2, min( lazyMatchLen - 2, srcEnd - (src + nRaw + 2) ) );
+                    hash = _updateTable( hash, src + nRaw + 1, bufPos + 2, min( lazyMatchLen - 2, srcEnd - (src + nRaw + 2) - LZMATCH ) );
                     _toBuf( src + nRaw, lazyMatchLen );
                     src += nRaw + lazyMatchLen;
                     break;//for( nRaw )
@@ -267,7 +267,7 @@ size_t LZHLCompressor::compress( BYTE* dst, const BYTE* src, size_t sz )
                 #endif
                 {
                 coder.putMatch( src, nRaw, matchLen - LZMIN, _distance( wrapBufPos - hashPos ) );
-                hash = _updateTable( hash, src + nRaw, bufPos + 1, min( matchLen - 1, srcEnd - (src + nRaw + 1) ) );
+                hash = _updateTable( hash, src + nRaw, bufPos + 1, min( matchLen - 1, srcEnd - (src + nRaw + 1) - LZMATCH ) );
                 _toBuf( src + nRaw, matchLen );
                 src += nRaw + matchLen;
                 break;//for( nRaw )
@@ -284,7 +284,7 @@ size_t LZHLCompressor::compress( BYTE* dst, const BYTE* src, size_t sz )
                 if( lazyMatchLen >= LZMIN )
                     {
                     coder.putMatch( src, nRaw, lazyMatchLen - LZMIN, _distance( bufPos - lazyMatchHashPos ) );
-                    hash = _updateTable( hash, src + nRaw, bufPos + 1, min( lazyMatchLen - 1, srcEnd - (src + nRaw + 1) ) );
+                    hash = _updateTable( hash, src + nRaw, bufPos + 1, min( lazyMatchLen - 1, srcEnd - (src + nRaw + 1) - LZMATCH ) );
                     _toBuf( src + nRaw, lazyMatchLen );
                     src += nRaw + lazyMatchLen;
                     break;//for( nRaw )


### PR DESCRIPTION
<img width="1622" height="238" alt="image" src="https://github.com/user-attachments/assets/c9270226-4323-40fb-be88-1dc9c135d867" />

When using LZHL compression it would read over the source buffers size.

In a different LZHL repo i found that he encountered the same issue and fixed it like this: 
https://github.com/ryandrake08/lzhl/commit/66c7e778442c2956edd5d9425408470e34c83cb5